### PR TITLE
Updated News plugin to work with News v1.71 Final

### DIFF
--- a/plugins/news.php
+++ b/plugins/news.php
@@ -8,7 +8,7 @@ function b_waiting_news()
     $block   = array();
 
     // news
-    $result = $xoopsDB->query('SELECT COUNT(*) FROM ' . $xoopsDB->prefix('stories') . ' WHERE published=0');
+    $result = $xoopsDB->query('SELECT COUNT(*) FROM ' . $xoopsDB->prefix('news_stories') . ' WHERE published=0');
     if ($result) {
         $block['adminlink'] = XOOPS_URL . '/modules/news/admin/index.php?op=newarticle';
         list($block['pendingnum']) = $xoopsDB->fetchRow($result);


### PR DESCRIPTION
Since the News table changed in latest NEws module, the News plugin of the Waiting module was checking for the old table. With this change it will work just fine.